### PR TITLE
Add Loki ruler config to loki.yml and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-Role Name
-=========
+# Fork of [diogenxs/ansible-role-loki](https://github.com/diogenxs/ansible-role-loki)
+
+- Added enabling systemd service 
+- Added loki_ruler config
+
+---
+
+Ansible Role Loki
+=================
 
 Deploy and configure [Loki/Promtail](https://github.com/grafana/loki) using Ansible.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,6 +76,7 @@ loki_table_manager_config:
   retention_deletes_enabled: false
   retention_period: 0s
 
+loki_ruler_config: []
 
 promtail_client_config:
   - url: "http://{{ loki_listen_address }}:{{ loki_listen_port }}/loki/api/v1/push"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,6 +5,7 @@
     daemon_reload: true
     name: loki
     state: restarted
+    enabled: true
   when: ('loki' in loki_bins)
 
 - name: reload loki
@@ -20,6 +21,7 @@
     daemon_reload: true
     name: promtail
     state: restarted
+    enabled: true
   when: ('promtail' in loki_bins)
 
 - name: reload promtail

--- a/templates/loki.yml.j2
+++ b/templates/loki.yml.j2
@@ -57,3 +57,7 @@ table_manager:
 runtime_config:
   {{ loki_runtime_config | to_nice_yaml(indent=2) | indent(2, False) }}
 {% endif %}
+{% if loki_ruler_config != [] %}
+ruler:
+  {{ loki_ruler_config | to_nice_yaml(indent=2) | indent(2, False) }}
+{% endif %}


### PR DESCRIPTION
This allows to use the [`ruler` setting for Loki](https://grafana.com/docs/loki/latest/rules/).