### PR TITLE
Follow redirects when fetching checksums file

### DIFF
--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -30,7 +30,7 @@
 - block:
     - name: Get checksum list
       set_fact:
-        __loki_checksums: "{{ lookup('url', 'https://github.com/grafana/loki/releases/download/v' + loki_version + '/SHA256SUMS', wantlist=True) | list }}"
+        __loki_checksums: "{{ lookup('url', 'https://github.com/grafana/loki/releases/download/v' + loki_version + '/SHA256SUMS', wantlist=True, follow_redirects='yes') | list }}"
       run_once: true
 
     - name: Get checksum for bins


### PR DESCRIPTION
This small change makes the "url lookup" follow HTTP redirects.
This was necessary to make it work for me.

...I believe I got a 302, so it's possible changing the URL to fetch is a good idea...but following redirects seems like an OK setting for this case regardless.