### PR TITLE
Enable service

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -83,3 +83,10 @@
   notify: "restart {{ item }}"
   loop: "{{ loki_bins }}"
   when: item == 'loki' or item == 'promtail'
+
+- name: enable service
+  service:
+    name: "{{ item }}"
+    enabled: true
+  loop: "{{ loki_bins }}"
+  when: item == 'loki' or item == 'promtail'


### PR DESCRIPTION
This commit makes sure that loki and/or promtail service are enabled.
Doing so will allow users to safely reboot a host without needing to
either apply the role or start the services manually.