### PR TITLE
systemd: set WorkingDirectory to fix relative mkdir

### DIFF
--- a/templates/loki.service.j2
+++ b/templates/loki.service.j2
@@ -9,6 +9,7 @@ Type=simple
 Environment="GOMAXPROCS={{ ansible_processor_vcpus|default(ansible_processor_count) }}"
 User={{ loki_user }}
 Group={{ loki_group }}
+WorkingDirectory={{ loki_storage_dir }}
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/loki \
   -config.file {{ loki_config_dir }}/loki.yml


### PR DESCRIPTION
Loki 2.4.1 tries to `mkdir` a path relative to the working directory,
which is problematic when it is not set to a path that is writeable by
the loki user.

> level=error ts=2021-12-02T16:18:14.974316503Z caller=log.go:106 msg="error running loki" err="mkdir wal: permission denied [...]"

Fixes this by setting the working directory to lokis storage directory.

Signed-off-by: Martin Weinelt <martin.weinelt@man-da.de>